### PR TITLE
Typographie-Nerdigkeit

### DIFF
--- a/satzung.tex
+++ b/satzung.tex
@@ -15,6 +15,9 @@
 \usepackage{xunicode}
 \defaultfontfeatures{Mapping=tex-text} % To support LaTeX quoting style
 
+% Optischer Randausgleich
+\usepackage[protrusion=true]{microtype}
+
 % Damit lässt sich die art von Aufzählungen ändern
 \usepackage{paralist}
 


### PR DESCRIPTION
Mit dem microtype-Paket kann LaTeX optischen Randausgleich betreiben: Damit werden zum Beispiel kurze Bindestriche mit Absicht etwas über den rechten Seitenrand hinaus gesetzt, damit es fürs menschliche Auge harmonisch aussieht.

Wenn man nicht XeLaTeX verwendet, kann man auch noch die Option expansion=true dazupacken. Die versucht, die Anzahl der Trennung durch minimale Anpassungen des Abstands zwischen Zeichen zu reduzieren.
